### PR TITLE
KEYCLOAK-3991: Node.js module should be available through a single file download

### DIFF
--- a/topics/oidc/nodejs-adapter.adoc
+++ b/topics/oidc/nodejs-adapter.adoc
@@ -12,6 +12,12 @@ To use the Node.js adapter, first you must create a client for your application 
 
 Once the client is created click on the `Installation` tab select `{{book.project.name}} OIDC JSON` for `Format Option` then click on `Download`. The downloaded `keycloak.json` file should be at the root folder of your project.
 
+==== Known issue
+
+Node.js adapter requires `realm-public-key` attribute and does not retrieve it automatically from {{book.project.name}}. Otherwise, your Node.js app won't start.
+
+In order to prevent any issues, go to your `Realm Settings` and `Keys`, copy the `Public Key` to your keycloak.json file adding `realm-public-key` attribute like the snippet below:
+
 [source,json]
 ----
 {
@@ -25,8 +31,6 @@ Once the client is created click on the `Installation` tab select `{{book.projec
   }
 }
 ----
-
-Please notice that `realm-public-key` attribute is mandatory. Otherwise, your Node.js app won't start.
 
 ==== Installation
 

--- a/topics/oidc/nodejs-adapter.adoc
+++ b/topics/oidc/nodejs-adapter.adoc
@@ -3,28 +3,30 @@
 
 {{book.project.name}} provides a Node.js adapter built on top of https://github.com/senchalabs/connect[Connect] to protect server side JavaScript apps — the goal was to be flexible enough to integrate with frameworks like https://expressjs.com/[Express.js].
 
+{% if book.community %}
 The library can be downloaded directly from https://www.npmjs.com/package/keycloak-connect[ {{book.project.name}} organization] and the source is available at
 https://github.com/keycloak/keycloak-nodejs-connect[GitHub].
+{% endif %}
 
-To use the Node.js adapter you must first create a client for your application in the {{book.project.name}} Administration Console. The adapter supports public, confidential and bearer-only access type. Which one to choose depends on the use-case scenario.
+To use the Node.js adapter, first you must create a client for your application in the {{book.project.name}} Administration Console. The adapter supports public, confidential and bearer-only access type. Which one to choose depends on the use-case scenario.
 
-Once the client is created click on the `Installation` tab select `{{book.project.name}} OIDC JSON` for `Format Option` then click on `Download`. The downloaded `keycloak.json` file should be at the root folder. Exactly, like in https://github.com/keycloak/keycloak-nodejs-connect/tree/master/example[this example].
+Once the client is created click on the `Installation` tab select `{{book.project.name}} OIDC JSON` for `Format Option` then click on `Download`. The downloaded `keycloak.json` file should be at the root folder of your project.
 
-keycloak.json::
+[source,json]
+----
+{
+  "realm": "example-realm",
+  "realm-public-key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
+  "auth-server-url": "http://localhost:8080/auth",
+  "ssl-required": "external",
+  "resource": "example-app",
+  "credentials": {
+    "secret": "mysecret"
+  }
+}
+----
 
-Alongside the `example.js` lives `keycloak.json` obtained from our {{book.project.name}}
-admin console when we provisioned this app.
-
-
-    {
-      "realm": "example-realm",
-      "auth-server-url": "http://localhost:8080/auth",
-      "ssl-required": "external",
-      "resource": "example-app",
-      "credentials": {
-        "secret": "mysecret"
-      }
-    }
+Please notice that `realm-public-key` attribute is mandatory. Otherwise, your Node.js app won't start.
 
 ==== Installation
 
@@ -32,9 +34,23 @@ Assuming you've already installed https://nodejs.org[Node.js], create a folder f
 
     mkdir myapp && cd myapp
 
-Use `npm init` command to create a `package.json` for your application. And now install the {{book.project.name}} connect adapter in the `myapp` folder, saving it in the dependencies list:
+Use `npm init` command to create a `package.json` for your application. Now add the {{book.project.name}} connect adapter in the dependencies list:
 
-    npm install --save keycloak-connect
+{% if book.community %}
+
+    dependencies": {
+        "keycloak-connect": "{{book.project.versionMvn}}"
+    }
+
+{% endif %}
+
+{% if book.product %}
+
+    dependencies": {
+        "keycloak-connect": "file://{{book.project.name}}.tgz"
+    }
+
+{% endif %}
 
 ==== Usage
 Instantiate a Keycloak class::


### PR DESCRIPTION
@stianst I tested this using the live preview for asciidoc. Although, when I run our `build.sh`, seems like the project name is not being replaced at the code snippet (https://github.com/abstractj/securing_apps_guide/commit/2c0fcb4fcf926df63e9e59c1de253c217f305ae8#diff-26fb6eb1861611eed154c8d1dd2bd11dR48).

Do we have any way to check that I didn't mess things up?